### PR TITLE
fix(ebpf): pass bpf verification on kernel 5.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Enable personal intercepts based on domain names rather than relying on header-b
 
 `pmz` utilizes eBPF, requiring the following system specifications:
 
-- **Linux Kernel**: 6.8 or higher
+- **Linux Kernel**: 5.15 or higher
   - I am also testing on older kernels like version 5.4.0.
 - **Supported Architectures**:
   - `amd64` (`x86_64`)
@@ -143,9 +143,9 @@ Enable personal intercepts based on domain names rather than relying on header-b
 Download and extract the appropriate release for your local machine:
 
 ```sh
-curl -OL https://github.com/wqld/pmz/releases/download/v0.1.3/pmz-0.1.3-${ARCH}-musl.tar.gz
+curl -OL https://github.com/wqld/pmz/releases/download/v0.1.4/pmz-0.1.4-${ARCH}-musl.tar.gz
 
-tar -xf pmz-0.1.3-${ARCH}-musl.tar.gz
+tar -xf pmz-0.1.4-${ARCH}-musl.tar.gz
 ```
 
 Don't be alarmed if you encounter messages like the following during extraction.

--- a/ctl/Cargo.toml
+++ b/ctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmzctl"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/wqld/pmz/tree/main/ctl"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmz"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/wqld/pmz"

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -65,6 +65,7 @@ async fn main() -> anyhow::Result<()> {
     tc_egress.load()?;
     tc_egress.attach(&iface, TcAttachType::Egress)?;
 
+    let _ = tc::qdisc_add_clsact("lo");
     let ingress_forwarder: &mut SchedClassifier =
         ebpf.program_mut("ingress_forwarder").unwrap().try_into()?;
     ingress_forwarder.load()?;

--- a/ebpf/src/resolver.rs
+++ b/ebpf/src/resolver.rs
@@ -12,7 +12,7 @@ use aya_ebpf::{
 use aya_log_ebpf::{debug, error};
 use common::{DnsHdr, DnsQuery, DnsRecordA, MAX_DNS_NAME_LENGTH};
 use network_types::{eth::EthHdr, ip::Ipv4Hdr, udp::UdpHdr};
-use pmz_ebpf::{class_to_str, record_type_to_str};
+// use pmz_ebpf::{class_to_str, record_type_to_str};
 
 use crate::{context::Context, SERVICE_REGISTRY};
 
@@ -101,13 +101,15 @@ impl<'a> DnsResolver<'a> {
 
         let query_len = self.parse_query(&mut dns_query)?;
 
-        debug!(
-            self.ctx.ctx,
-            "DNS_NAME={} DNS_TYPE={} DNS_CLASS={}",
-            unsafe { str::from_utf8_unchecked(&dns_query.name) },
-            record_type_to_str(dns_query.record_type),
-            class_to_str(dns_query.class),
-        );
+        // TODO: need to check
+        // The BPF verifier rejects the following debug! macro on kernel versions 5.15 and below.
+        // debug!(
+        //     self.ctx.ctx,
+        //     "DNS_NAME={} DNS_TYPE={} DNS_CLASS={}",
+        //     unsafe { str::from_utf8_unchecked(&dns_query.name) },
+        //     record_type_to_str(dns_query.record_type),
+        //     class_to_str(dns_query.class),
+        // );
 
         match unsafe { SERVICE_REGISTRY.get(&dns_query) } {
             Some(a_record) => {


### PR DESCRIPTION
```sh
$ uname -a
Linux wq 5.15.0-130-generic #140-Ubuntu SMP Wed Dec 18 17:59:36 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux

$ RUST_LOG=debug ./target/debug/pmz --iface enp0s1
...
Waiting for Ctrl-C...
[DEBUG pmz::proxy] Proxy: Listening on 127.0.0.1:18328
[DEBUG pmz::command] Listening for connections at /tmp/pmz.sock.
```