### PR TITLE
refactor: improve tunneling logic to support a wide range of protocols

### DIFF
--- a/daemon/src/command.rs
+++ b/daemon/src/command.rs
@@ -30,11 +30,11 @@ use crate::{
     discovery::Discovery,
     forward::Forward,
     route::Route,
-    tunnel::Tunnel,
+    tunnel::{Tunnel, TunnelRequest},
 };
 
 pub struct Command {
-    req_rx: Arc<Mutex<Receiver<HttpRequest>>>,
+    req_rx: Arc<Mutex<Receiver<TunnelRequest>>>,
     service_registry: Arc<RwLock<HashMap<MapData, DnsQuery, DnsRecordA>>>,
     service_cidr_map: Arc<RwLock<HashMap<MapData, u8, u32>>>,
     connection_manager: Arc<Mutex<ConnectionManager>>,
@@ -42,7 +42,7 @@ pub struct Command {
 
 impl Command {
     pub fn new(
-        req_rx: Receiver<HttpRequest>,
+        req_rx: Receiver<TunnelRequest>,
         service_registry: HashMap<MapData, DnsQuery, DnsRecordA>,
         service_cidr_map: HashMap<MapData, u8, u32>,
     ) -> Self {
@@ -101,7 +101,7 @@ impl Command {
 
 async fn handle_request(
     req: Request<Incoming>,
-    req_rx: Arc<Mutex<Receiver<HttpRequest>>>,
+    req_rx: Arc<Mutex<Receiver<TunnelRequest>>>,
     service_registry: Arc<RwLock<HashMap<MapData, DnsQuery, DnsRecordA>>>,
     service_cidr_map: Arc<RwLock<HashMap<MapData, u8, u32>>>,
     connection_manager: Arc<Mutex<ConnectionManager>>,
@@ -174,7 +174,7 @@ async fn delete_agent() -> Result<Response<Full<Bytes>>> {
 }
 
 async fn connect(
-    req_rx: Arc<Mutex<Receiver<HttpRequest>>>,
+    req_rx: Arc<Mutex<Receiver<TunnelRequest>>>,
     service_registry: Arc<RwLock<HashMap<MapData, DnsQuery, DnsRecordA>>>,
     service_cidr_map: Arc<RwLock<HashMap<MapData, u8, u32>>>,
     connection_manager: Arc<Mutex<ConnectionManager>>,
@@ -427,12 +427,4 @@ async fn not_found() -> Result<Response<Full<Bytes>>> {
     Ok(Response::builder()
         .status(StatusCode::NOT_FOUND)
         .body(Full::<Bytes>::from("Not found"))?)
-}
-
-pub struct HttpRequest {
-    pub method: http::Method,
-    pub request: String,
-    pub _source: String,
-    pub target: String,
-    pub response: Option<tokio::sync::oneshot::Sender<Bytes>>,
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -3,12 +3,13 @@ use aya::{
     programs::{tc, SchedClassifier, TcAttachType},
 };
 use clap::Parser;
-use command::{Command, HttpRequest};
+use command::Command;
 use common::{DnsQuery, DnsRecordA, NatKey, NatOrigin};
 use log::{debug, warn};
 use proxy::Proxy;
 use sudo::PrivilegeLevel;
 use tokio::signal;
+use tunnel::TunnelRequest;
 
 mod command;
 mod connect;
@@ -77,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
     egress_forwarder.load()?;
     egress_forwarder.attach("lo", TcAttachType::Egress)?;
 
-    let (req_tx, req_rx) = tokio::sync::mpsc::channel::<HttpRequest>(1);
+    let (req_tx, req_rx) = tokio::sync::mpsc::channel::<TunnelRequest>(1);
 
     let nat_table: HashMap<_, NatKey, NatOrigin> =
         HashMap::try_from(ebpf.take_map("NAT_TABLE").unwrap())?;


### PR DESCRIPTION
Refactor tunneling logic to support a wider range of protocols, including TCP, HTTP/1.1, HTTP/2, and TLS, thereby increasing compatibility and functionality.

```sh
# GET
> curl "echo.default.svc:80/?echo_body=amazing" -v
* Host echo.default.svc:80 was resolved.
* IPv6: (none)
* IPv4: 10.96.90.29
*   Trying 10.96.90.29:80...
* Connected to echo.default.svc (10.96.90.29) port 80
> GET /?echo_body=amazing HTTP/1.1
> Host: echo.default.svc
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Content-Length: 9
< ETag: W/"9-9C3TDmXfhoWPizWzjFyCX+fxVeQ"
< Date: Mon, 27 Jan 2025 04:30:48 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
* Connection #0 to host echo.default.svc left intact
"amazing"⏎
```

```sh
# POST
> curl -X POST "http.default.svc:8080/api/todos" --data '{"title":"123","description":"456","completed":false,"id":6}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host http.default.svc:8080 was resolved.
* IPv6: (none)
* IPv4: 10.96.11.61
*   Trying 10.96.11.61:8080...
* Connected to http.default.svc (10.96.11.61) port 8080
> POST /api/todos HTTP/1.1
> Host: http.default.svc:8080
> User-Agent: curl/8.5.0
> Accept: */*
> Content-Length: 60
> Content-Type: application/x-www-form-urlencoded
>
< HTTP/1.1 201 Created
< Content-Type: application/json
< Date: Mon, 27 Jan 2025 04:34:50 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
<
* Connection #0 to host http.default.svc left intact
{"id":6,"title":"123","description":"456","completed":false}⏎
```

```sh
# http/2 w/ TLS
> curl "https://kubernetes.default.svc" -kv
* Host kubernetes.default.svc:443 was resolved.
* IPv6: (none)
* IPv4: 10.96.0.1
*   Trying 10.96.0.1:443...
* Connected to kubernetes.default.svc (10.96.0.1) port 443
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=kube-apiserver
*  start date: Jan 24 09:31:42 2025 GMT
*  expire date: Jan 24 09:36:42 2026 GMT
*  issuer: CN=kubernetes
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://kubernetes.default.svc/
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: kubernetes.default.svc]
* [HTTP/2] [1] [:path: /]
* [HTTP/2] [1] [user-agent: curl/8.5.0]
* [HTTP/2] [1] [accept: */*]
> GET / HTTP/2
> Host: kubernetes.default.svc
> User-Agent: curl/8.5.0
> Accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* received GOAWAY, error=0, last_stream=1
< HTTP/2 403
< audit-id: 13387922-06e5-45dd-a9ff-9f9bca728365
< cache-control: no-cache, private
< content-type: application/json
< x-content-type-options: nosniff
< x-kubernetes-pf-flowschema-uid: 1fb12a00-e636-4c9d-80ae-66921cf9a4e4
< x-kubernetes-pf-prioritylevel-uid: 602dd39b-1b4e-4e95-bdb1-3b94c01d3ec3
< content-length: 217
< date: Mon, 27 Jan 2025 04:31:37 GMT
<
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "forbidden: User \"system:anonymous\" cannot get path \"/\"",
  "reason": "Forbidden",
  "details": {},
  "code": 403
* Closing connection
* TLSv1.3 (OUT), TLS alert, close notify (256):
}⏎
```

```sh
# streaming method like transfer-encoding chunked
> curl "http.default.svc:8080/api/todos" -v
* Host http.default.svc:8080 was resolved.
* IPv6: (none)
* IPv4: 10.96.11.61
*   Trying 10.96.11.61:8080...
* Connected to http.default.svc (10.96.11.61) port 8080
> GET /api/todos HTTP/1.1
> Host: http.default.svc:8080
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Mon, 27 Jan 2025 04:24:52 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
<
* Connection #0 to host http.default.svc left intact
[{"id":1,"title":"Coding in Javascript","description":"Working with functions in JavaScript","
completed":false},{"id":2,"title":"Cooking Supper","description":"Preparing rice and chicken",
"completed":false},{"id":3,"title":"Taking a walk","description":"Easy time at the park","comp
leted":false},{"id":4,"title":"Watching Netflix","description":"Enjoying the new premiered ser
ies","completed":false}]⏎
```

```sh
# TCP
> echo pmz! | nc tcp.default.svc 9000 -v
Connection to tcp.default.svc (10.96.196.255) 9000 port [tcp/*] succeeded!
hello pmz!
```