### PR TITLE
refactor: consolidate intercept rule ctrl into agent

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -4,11 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [[bin]]
-doc = false
-name = "ctrl"
-path = "src/ctrl/app.rs"
-
-[[bin]]
 name = "crdgen"
 path = "src/ctrl/crdgen.rs"
 

--- a/agent/src/ctrl/lib.rs
+++ b/agent/src/ctrl/lib.rs
@@ -27,5 +27,5 @@ pub struct InterceptRuleSpec {
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct InterceptRuleStatus {
-    last_updated: Option<DateTime<Utc>>,
+    pub last_updated: Option<DateTime<Utc>>,
 }

--- a/agent/src/ctrl/mod.rs
+++ b/agent/src/ctrl/mod.rs
@@ -1,0 +1,3 @@
+mod app;
+
+pub use app::*;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -25,6 +25,7 @@ use tokio::sync::{Mutex, RwLock, mpsc};
 use tonic::transport;
 use uuid::Uuid;
 
+mod ctrl;
 mod discovery;
 mod server;
 
@@ -73,6 +74,13 @@ async fn main() -> Result<()> {
             .serve(addr)
             .await
             .unwrap()
+    });
+
+    // controller thread
+    tokio::spawn(async move {
+        ctrl::run()
+            .await
+            .expect("Failed to run InterceptRule controller");
     });
 
     let dial_map: HashMap<Uuid, mpsc::Sender<DialRequest>> = HashMap::new();

--- a/daemon/src/deploy.rs
+++ b/daemon/src/deploy.rs
@@ -350,12 +350,31 @@ impl<'a> Deploy<'a> {
                 ..Default::default()
             },
             rules: Some({
-                vec![PolicyRule {
-                    api_groups: Some(vec!["".to_owned()]),
-                    resources: Some(vec!["services".to_owned()]),
-                    verbs: vec!["get".to_owned(), "watch".to_owned(), "list".to_owned()],
-                    ..Default::default()
-                }]
+                vec![
+                    PolicyRule {
+                        api_groups: Some(vec!["".to_owned()]),
+                        resources: Some(vec!["pods".to_owned(), "services".to_owned()]),
+                        verbs: vec!["get".to_owned(), "watch".to_owned(), "list".to_owned()],
+                        ..Default::default()
+                    },
+                    PolicyRule {
+                        api_groups: Some(vec!["pmz.sinabro.io".to_owned()]),
+                        resources: Some(vec!["interceptrules".to_owned()]),
+                        verbs: vec![
+                            "get".to_owned(),
+                            "watch".to_owned(),
+                            "list".to_owned(),
+                            "patch".to_owned(),
+                        ],
+                        ..Default::default()
+                    },
+                    PolicyRule {
+                        api_groups: Some(vec!["pmz.sinabro.io".to_owned()]),
+                        resources: Some(vec!["interceptrules/status".to_owned()]),
+                        verbs: vec!["get".to_owned(), "patch".to_owned()],
+                        ..Default::default()
+                    },
+                ]
             }),
         };
 

--- a/proto/intercept.proto
+++ b/proto/intercept.proto
@@ -18,7 +18,7 @@ message DiscoveryResponse {
 message InterceptEndpoint {
   repeated PodIdentifier pod_ids = 1;
   string namespace = 2;
-  string target_port = 3;
+  int32 target_port = 3;
 }
 
 message PodIdentifier {


### PR DESCRIPTION
Consolidate intercept-rule ctrl into agent

```sh
[INFO  agent::ctrl::app[] Successfully updated status.last_updated for InterceptRule 'default/
[DEBUG agent::ctrl::app[] Rule: default/ir-1, Service Port: 80, Found targetPort: Int(80)
[DEBUG agent::ctrl::app[] Rule: default/ir-1, Resolved intercept endpoint: InterceptEndpoint {
[INFO  agent::ctrl::app[] Rule: default/ir-1, TODO: Send intercept endpoint data
```