### PR TITLE
feat(agent): Send target pod details for interception to pmz-cni

### DIFF
--- a/agent/src/discovery.rs
+++ b/agent/src/discovery.rs
@@ -6,8 +6,9 @@ use tokio::sync::{RwLock, mpsc};
 use tokio_stream::{Stream, wrappers::ReceiverStream};
 use tonic::{Request, Response, Status};
 
+use crate::DiscovertTx;
+
 type InterceptResult<T> = Result<Response<T>, Status>;
-type DiscovertTx = mpsc::Sender<Result<DiscoveryResponse, Status>>;
 type ResponseStream = Pin<Box<dyn Stream<Item = Result<DiscoveryResponse, Status>> + Send>>;
 
 pub struct DiscoveryServer {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -22,12 +22,14 @@ use proxy::{
 use server::InterceptTunnel;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, RwLock, mpsc};
-use tonic::transport;
+use tonic::{Status, transport};
 use uuid::Uuid;
 
 mod ctrl;
 mod discovery;
 mod server;
+
+type DiscovertTx = mpsc::Sender<Result<proto::DiscoveryResponse, Status>>;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -76,9 +78,11 @@ async fn main() -> Result<()> {
             .unwrap()
     });
 
+    let subs_clone = subs.clone();
+
     // controller thread
     tokio::spawn(async move {
-        ctrl::run()
+        ctrl::run(subs_clone)
             .await
             .expect("Failed to run InterceptRule controller");
     });

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tonic = { version = "0.13", default-features = false, features = ["prost", "codegen"] }
 prost = "0.13"
 prost-types = "0.13"
+tonic = { version = "0.13", default-features = false, features = ["prost", "codegen"] }
 
 [build-dependencies]
 tonic-build = { version = "0.13", default-features = false, features = ["prost"] }


### PR DESCRIPTION
pmz-agent: reconciliation

```sh
[DEBUG agent::ctrl::app] Rule: default/ir-1, Resolved intercept endpoint: InterceptEndpoint {
pod_ids: [PodIdentifier { name: "echo", ip: "10.244.0.10", host_ip: "172.18.0.3" }], namespace
: "default", target_port: 80 }
[DEBUG agent::ctrl::app] Sending update to subscriber at 172.18.0.3: DiscoveryResponse { versi
on_info: "v1.0-alpha", resources: [InterceptEndpoint { pod_ids: [PodIdentifier { name: "echo",
 ip: "10.244.0.10", host_ip: "172.18.0.3" }], namespace: "default", target_port: 80 }] }
[DEBUG agent::ctrl::app] All found subscribers notified (or send attempted). Requesting long r
equeue.
[INFO  agent::ctrl::app] Rule: default/ir-1, Action: Action { requeue_after: Some(3600s) }, Du
ration: 2.543732ms, Reconciliation successful.
```

pmz-cni: subscriber

```sh
pmz-cni [DEBUG cni] received: Ok(DiscoveryResponse { version_info: "v1.0-alpha", resources: [I
nterceptEndpoint { pod_ids: [PodIdentifier { name: "echo", ip: "10.244.0.10", host_ip: "172.18
.0.3" }], namespace: "default", target_port: 80 }] })
```