### PR TITLE
refactor: optimize stream dispatch

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -14,6 +14,7 @@ use k8s_openapi::api::discovery::v1::EndpointSlice;
 use kube::api::{ListParams, Patch, PatchParams};
 use kube::runtime::{WatchStreamExt, watcher};
 use kube::{Api, ResourceExt};
+use proxy::tunnel::TcpListenerTunnelExt;
 use proxy::{
     DialRequest, InterceptRouteKey, InterceptRouteMap, InterceptRuleKey, InterceptRuleMap,
     InterceptValue,
@@ -382,7 +383,7 @@ async fn main() -> Result<()> {
         debug!("Intercep Gate: Listening on {addr}");
 
         loop {
-            let (mut stream, peer_addr) = listener.accept().await.unwrap();
+            let (mut stream, peer_addr) = listener.accept_tun().await.unwrap();
             debug!("peer_addr: {peer_addr:?}");
 
             let mut original_dst_heder = [0u8; 6];

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -6,7 +6,7 @@ use h2::{RecvStream, SendStream, server::SendResponse};
 use http::Request;
 use proxy::{
     DialRequest, InterceptContext, InterceptRequest, InterceptRuleKey, InterceptValue,
-    tunnel::stream::TunnelStream,
+    tunnel::{TcpListenerTunnelExt, stream::TunnelStream},
 };
 use tokio::{
     net::{TcpListener, TcpStream},
@@ -61,7 +61,7 @@ impl InterceptTunnel {
         info!("Listening on {}", addr);
 
         loop {
-            if let Ok((stream, peer_addr)) = listener.accept().await {
+            if let Ok((stream, peer_addr)) = listener.accept_tun().await {
                 let state = self.state.clone();
 
                 tokio::spawn(
@@ -317,10 +317,6 @@ async fn intercept(
             recv,
             send: send_stream,
         };
-        // let mut upstream = match state.stream_map.lock().await.remove(&intercept_req) {
-        //     Some(stream) => stream,
-        //     None => todo!(),
-        // };
 
         debug!("Starting bidirectional copy");
 

--- a/cni/Cargo.toml
+++ b/cni/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/plugin/main.rs"
 
 [dependencies]
 ctrl = { package = "agent", path = "../agent" }
+proxy = { package = "proxy", path = "../proxy"}
 
 anyhow = { workspace = true, default-features = true }
 clap = { workspace = true, features = ["derive"] }

--- a/daemon/src/intercept.rs
+++ b/daemon/src/intercept.rs
@@ -8,6 +8,7 @@ use k8s_openapi::api::core::v1::Pod;
 use proxy::{
     InterceptContext, InterceptRequest,
     tunnel::{
+        TcpStreamTunnelExt,
         client::{TunnelClient, establish_h2_with_forward},
         stream::TunnelStream,
     },
@@ -287,7 +288,7 @@ pub async fn establish_intercept_tunnel(
 
     let mut downstream = TunnelStream { recv, send };
     let target_addr = format!("localhost:{}", target_port);
-    let mut upstream = TcpStream::connect(target_addr).await?;
+    let mut upstream = TcpStream::connect_tun(target_addr).await?;
 
     tokio::io::copy_bidirectional(&mut downstream, &mut upstream).await?;
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -18,7 +18,7 @@ use tokio::{
     signal,
     sync::{RwLock, mpsc},
 };
-use tracing::{debug, warn};
+use tracing::debug;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 mod command;

--- a/proxy/src/tunnel.rs
+++ b/proxy/src/tunnel.rs
@@ -1,3 +1,8 @@
+use std::{io, net::SocketAddr, time::Duration};
+
+use socket2::{SockRef, TcpKeepalive};
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+
 pub mod client;
 pub mod server;
 pub mod stream;
@@ -19,5 +24,47 @@ impl PROTO {
         }
 
         PROTO::TCP
+    }
+}
+
+pub trait TcpListenerTunnelExt {
+    fn accept_tun(&self) -> impl Future<Output = io::Result<(TcpStream, SocketAddr)>> + Send + '_;
+}
+
+impl TcpListenerTunnelExt for TcpListener {
+    async fn accept_tun(&self) -> io::Result<(TcpStream, SocketAddr)> {
+        let (stream, addr) = self.accept().await?;
+
+        stream.set_nodelay(true)?;
+
+        let ka = TcpKeepalive::new()
+            .with_time(Duration::from_secs(45))
+            .with_interval(Duration::from_secs(10))
+            .with_retries(5);
+
+        SockRef::from(&stream).set_tcp_keepalive(&ka)?;
+
+        Ok((stream, addr))
+    }
+}
+
+pub trait TcpStreamTunnelExt {
+    fn connect_tun<A: ToSocketAddrs>(addr: A) -> impl Future<Output = io::Result<TcpStream>>;
+}
+
+impl TcpStreamTunnelExt for TcpStream {
+    async fn connect_tun<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
+        let stream = TcpStream::connect(addr).await?;
+
+        stream.set_nodelay(true)?;
+
+        let ka = TcpKeepalive::new()
+            .with_time(Duration::from_secs(45))
+            .with_interval(Duration::from_secs(10))
+            .with_retries(5);
+
+        SockRef::from(&stream).set_tcp_keepalive(&ka)?;
+
+        Ok(stream)
     }
 }

--- a/proxy/src/tunnel/client.rs
+++ b/proxy/src/tunnel/client.rs
@@ -11,12 +11,12 @@ use kube::{
 };
 use tokio::{
     fs::File,
-    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+    io::AsyncWriteExt,
     sync::{Mutex, broadcast, mpsc::Receiver, oneshot},
 };
 use tracing::{Instrument, debug, error, info, instrument};
 
-use crate::tunnel::stream::TunnelStream;
+use crate::tunnel::stream::{ProxyStream, TunnelStream};
 
 use super::PMZ_PROTO_HDR;
 
@@ -283,12 +283,8 @@ pub async fn establish_h2_with_forward(
     Ok((sender, Box::pin(conn), ping_pong))
 }
 
-pub trait Stream: AsyncRead + AsyncWrite + Unpin + Send {}
-
-impl<T> Stream for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
-
 pub struct TunnelRequest {
     pub protocol: &'static str,
-    pub stream: Box<dyn Stream>,
+    pub stream: ProxyStream,
     pub target: String,
 }


### PR DESCRIPTION
- Replace `Box<dyn Stream>` with `ProxyStream` enum to eliminate heap allocations and dynamic dispatch overhead in `TunnelRequest`.
- Introduce `accept_tun` and `connect_tun` helpers to consistently apply socket options (nodelay, keepalive) for connections.